### PR TITLE
Increase timeout and enable http_compress

### DIFF
--- a/kuiper/app/database/elkdb.py
+++ b/kuiper/app/database/elkdb.py
@@ -91,7 +91,9 @@ class ES_DB:
         transport_args = {}
         if ca_file is not None:
             transport_args = {'ssl_context': create_ssl_context(cafile=ca_file)}
-        self.es_db = Elasticsearch(es_url.split(','), api_key=api_key, timeout=120, **transport_args)
+        self.es_db = Elasticsearch(es_url.split(','), api_key=api_key, timeout=1200,
+                    http_compress=True,
+                    **transport_args)
         #print inspect.getargspec(self.es_db.indices.put_settings())
         # setting 
 


### PR DESCRIPTION
Increase the timeout for elasticsearch queries and enable `http_compression`.
Some queries were simply taking longer than the old timeout option and failed because of that. `http_compression` is off by default, but recommended when requests traverse the network and automatically enabled for elastic cloud